### PR TITLE
Add Developing for Accessibility talk

### DIFF
--- a/advocacy/developing_for_accessibility.yaml
+++ b/advocacy/developing_for_accessibility.yaml
@@ -1,0 +1,16 @@
+name: Aaron Krauss
+title: Developing for Accessibility
+url: https://www.thunderplainsconf.com/
+date: 2022-10-28
+description: >
+  In this talk, we'll be talking about prioritizing accessibility when
+  developing for the web. Despite what we envision, not every user is 100%
+  comfortable as far as mental and physical capabilities go - and there's no
+  excuse for ignoring that. Building an accessible product almost always leads
+  to a much more well-architected product - so it's a win-win.
+  We'll cover the tools and strategies you can use to aid users with visual,
+  auditory, cognitive, and motor impairments. We'll discuss contrast, colors,
+  content, keyboard flows, screen readers, section 508 - as well as skip menus,
+  the accessibility tree, hover and focus indicators, ARIA properties, and more.
+  There's a lot that developers and designers can do to aid users with
+  impairments - so let's do it!


### PR DESCRIPTION
This PR adds a new file for a no/low code Hacktoberfest contribution for a full-length talk I'll be giving soon at ThunderPlains later this month on 2022-10-28, titled Developing for Accessibility.