### PR TITLE
Removed out of place URL from Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo keeps track of [Techlahoma's](https://www.techlahoma.org/) contributio
 
 **Table of Contents**
 * [Hacktoberfest](#hacktoberfest)
-  * [Summary](#summary)https://github.com/Hacampbe/Hacktoberfest.git
+  * [Summary](#summary)
   * [Setup](#setup)
   * [Usage](#usage)
   * [Low or Non-Code Contributions](#low-or-non-code-contributions)


### PR DESCRIPTION
Removed URL (https://github.com/Hacampbe/Hacktoberfest.git) from TOC next to the Summary link.